### PR TITLE
Update azure.yaml with unique template name

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
-name: remote-mcp-functions-python
+name: remote-mcp-apim-functions-python
 metadata:
-  template: remote-mcp-functions-python@1.0.0
+  template: remote-mcp-apim-functions-python@1.0.0
 services:
   api:
     project: ./src/


### PR DESCRIPTION
This pull request updates the `azure.yaml` file to reflect a new naming convention for the project and its associated template.

Without this fix this template is indistinguishable from its sibling, that has no APIM.  

* **Project and template renaming:**
  - Updated the `name` field from `remote-mcp-functions-python` to `remote-mcp-apim-functions-python`.
  - Updated the `template` field from `remote-mcp-functions-python@1.0.0` to `remote-mcp-apim-functions-python@1.0.0`.## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
