### PR TITLE
Sandervd/fix invalid signature

### DIFF
--- a/infra/app/apim-mcp/mcp-api.policy.xml
+++ b/infra/app/apim-mcp/mcp-api.policy.xml
@@ -24,10 +24,10 @@
             
             return Encoding.UTF8.GetString(decryptedBytes);
         }" />
-        <cache-lookup-value key="@($"EntraToken-{context.Variables.GetValueOrDefault("decryptedSessionKey")}")" variable-name="accessToken" />
+        <cache-lookup-value key="@($"EntraToken-{context.Variables.GetValueOrDefault("decryptedSessionKey")}")" variable-name="token" />
         
         <choose>
-            <when condition="@(context.Variables.GetValueOrDefault("accessToken") == null)">
+            <when condition="@(context.Variables.GetValueOrDefault("token") == null)">
                 <return-response>
                     <set-status code="401" reason="Unauthorized" />
                     <set-header name="WWW-Authenticate" exists-action="override">
@@ -40,6 +40,52 @@
         <set-header name="x-functions-key" exists-action="override">
             <value>{{function-host-key}}</value>
         </set-header>
+
+        <!-- Modify request body to include the bearer token in the params section -->
+        <choose>
+            <when condition="@(context.Request.Body != null && context.Request.Body.As<JObject>(preserveContent: true) != null)">
+                <!-- If body exists and is valid JSON, add token to the params section -->
+                <set-body>@{
+                    var requestBody = context.Request.Body.As<JObject>(preserveContent: true);
+                    if (requestBody["params"] != null && requestBody["params"].Type == JTokenType.Object)
+                    {
+                        var paramsObj = (JObject)requestBody["params"];
+                        // Look for arguments section or create it if it doesn't exist
+                        if (paramsObj["arguments"] != null && paramsObj["arguments"].Type == JTokenType.Object)
+                        {
+                            // Add bearer token to the arguments section
+                            var argumentsObj = (JObject)paramsObj["arguments"];
+                            argumentsObj["bearerToken"] = (string)context.Variables.GetValueOrDefault("token");
+                        }
+                        else if (paramsObj["arguments"] == null)
+                        {
+                            // Create arguments section if it doesn't exist
+                            paramsObj["arguments"] = new JObject();
+                            ((JObject)paramsObj["arguments"])["bearerToken"] = (string)context.Variables.GetValueOrDefault("token");
+                        }
+                        else
+                        {
+                            // Fallback: add directly to params if arguments exists but is not an object
+                            paramsObj["bearerToken"] = (string)context.Variables.GetValueOrDefault("token");
+                        }
+                    }
+                    else
+                    {
+                        // If params section doesn't exist or isn't an object, just add to root as fallback
+                        requestBody["bearerToken"] = (string)context.Variables.GetValueOrDefault("token");
+                    }
+                    return requestBody.ToString();
+                }</set-body>
+            </when>
+            <otherwise>
+                <!-- If no body or not JSON, create a new JSON body with the token -->
+                <set-body>@{
+                    var newBody = new JObject();
+                    newBody["bearerToken"] = (string)context.Variables.GetValueOrDefault("bearer");
+                    return newBody.ToString();
+                }</set-body>
+            </otherwise>
+        </choose>        
     </inbound>
     <backend>
         <base />

--- a/infra/app/apim-oauth/entra-app.bicep
+++ b/infra/app/apim-oauth/entra-app.bicep
@@ -21,6 +21,20 @@ var issuer = '${loginEndpoint}${tenantId}/v2.0'
 resource entraApp 'Microsoft.Graph/applications@v1.0' = {
   displayName: entraAppDisplayName
   uniqueName: entraAppUniqueName
+  api: {
+    oauth2PermissionScopes: [
+      {
+        id: guid(entraAppUniqueName, 'access_as_user') // Generates a deterministic GUID
+        adminConsentDescription: 'Allow the application to access resources on behalf of the signed-in user.'
+        adminConsentDisplayName: 'Access resources on behalf of signed-in user'
+        isEnabled: true
+        type: 'User'
+        userConsentDescription: 'Allow the application to access resources on your behalf.'
+        userConsentDisplayName: 'Access resources on your behalf'
+        value: 'access_as_user'
+      }
+    ]
+  }
   web: {
     redirectUris: [
       apimOauthCallback
@@ -47,6 +61,19 @@ resource entraApp 'Microsoft.Graph/applications@v1.0' = {
     issuer: issuer
     subject: userAssignedIdentityPrincipleId
   }
+}
+
+// Update the application with its own appId in the identifier URI
+resource entraResourceAppUpdate 'Microsoft.Graph/applications@v1.0' = {
+  identifierUris: [
+    'api://${entraApp.appId}'
+  ]
+  // Keep all other properties the same as the original resource
+  displayName: entraAppDisplayName
+  uniqueName: entraAppUniqueName
+  api: entraApp.api
+  web: entraApp.web
+  requiredResourceAccess: entraApp.requiredResourceAccess
 }
 
 // Outputs

--- a/infra/app/apim-oauth/oauth-callback.policy.xml
+++ b/infra/app/apim-oauth/oauth-callback.policy.xml
@@ -31,7 +31,7 @@
             <value>application/x-www-form-urlencoded</value>
         </set-header>
         <set-body>@{
-            return $"client_id={context.Variables.GetValueOrDefault("clientId")}&grant_type=authorization_code&code={context.Variables.GetValueOrDefault("authCode")}&redirect_uri={context.Variables.GetValueOrDefault("redirectUri")}&scope=https://graph.microsoft.com/.default&code_verifier={context.Variables.GetValueOrDefault("codeVerifier")}&client_assertion_type={context.Variables.GetValueOrDefault("clientAssertionType")}&client_assertion={context.Variables.GetValueOrDefault("ficToken")}";
+            return $"client_id={context.Variables.GetValueOrDefault("clientId")}&grant_type=authorization_code&code={context.Variables.GetValueOrDefault("authCode")}&redirect_uri={context.Variables.GetValueOrDefault("redirectUri")}&scope=api://{context.Variables.GetValueOrDefault("clientId")}/access_as_user&code_verifier={context.Variables.GetValueOrDefault("codeVerifier")}&client_assertion_type={context.Variables.GetValueOrDefault("clientAssertionType")}&client_assertion={context.Variables.GetValueOrDefault("ficToken")}";
         }</set-body>
         <rewrite-uri template="/token" />
     </inbound>

--- a/infra/app/apim-oauth/oauth.bicep
+++ b/infra/app/apim-oauth/oauth.bicep
@@ -6,7 +6,7 @@ param location string
 
 // Parameters for Named Values
 @description('The required scopes for authorization')
-param oauthScopes string
+param oauthScope string
 
 @description('The principle id of the user-assigned managed identity for Entra app')
 param entraAppUserAssignedIdentityPrincipleId string
@@ -145,7 +145,7 @@ resource OAuthScopesNamedValue 'Microsoft.ApiManagement/service/namedValues@2021
   name: 'OAuthScopes'
   properties: {
     displayName: 'OAuthScopes'
-    value: oauthScopes
+    value: 'api://${entraApp.outputs.entraAppId}/${oauthScope}'
     secret: false
   }
 }
@@ -399,3 +399,4 @@ resource oauthConsentPostPolicy 'Microsoft.ApiManagement/service/apis/operations
 }
 
 output apiId string = oauthApi.id
+output entraAppId string = entraApp.outputs.entraAppId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,7 +30,7 @@ param disableLocalAuth bool = true
 
 // MCP Client APIM gateway specific variables
 
-var oauth_scopes = 'openid https://graph.microsoft.com/.default'
+var oauth_scope = 'access_as_user'
 
 
 var abbrs = loadJsonContent('./abbreviations.json')
@@ -68,7 +68,7 @@ module oauthAPIModule './app/apim-oauth/oauth.bicep' = {
     entraAppUniqueName: !empty(mcpEntraApplicationUniqueName) ? mcpEntraApplicationUniqueName : 'mcp-oauth-${abbrs.applications}${apimResourceToken}'
     entraAppDisplayName: !empty(mcpEntraApplicationDisplayName) ? mcpEntraApplicationDisplayName : 'MCP-OAuth-${abbrs.applications}${apimResourceToken}'
     apimServiceName: apimService.name
-    oauthScopes: oauth_scopes
+    oauthScope: oauth_scope
     entraAppUserAssignedIdentityPrincipleId: apimService.outputs.entraAppUserAssignedIdentityPrincipleId
     entraAppUserAssignedIdentityClientId: apimService.outputs.entraAppUserAssignedIdentityClientId
   }

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -197,15 +197,33 @@ tool_properties_get_snippets_object = [ToolProperty(_SNIPPET_NAME_PROPERTY_NAME,
 tool_properties_save_snippets_json = json.dumps([prop.__dict__ for prop in tool_properties_save_snippets_object])
 tool_properties_get_snippets_json = json.dumps([prop.__dict__ for prop in tool_properties_get_snippets_object])
 
-
 @app.generic_trigger(
     arg_name="context",
     type="mcpToolTrigger",
     toolName="hello_mcp",
-    description="Hello world with JWT token validation.",
+    description="Hello world.",
     toolProperties="[]",
 )
 def hello_mcp(context) -> str:
+    """
+    A simple function that returns a greeting message.
+
+    Args:
+        context: The trigger context (not used in this function).
+
+    Returns:
+        str: A greeting message.
+    """
+    return "Hello I am MCPTool!"
+
+@app.generic_trigger(
+    arg_name="context",
+    type="mcpToolTrigger",
+    toolName="validate_token",
+    description="Performs JWT token validation.",
+    toolProperties="[]",
+)
+def validate_token(context) -> str:
     """
     A function that validates a JWT token and returns validation results.
 

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
 import json
 import logging
+import base64
+import requests
+from typing import Dict, Any, Optional
 
 import azure.functions as func
+import jwt
+from jwt import PyJWKClient
+from cryptography.hazmat.primitives import serialization
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 
@@ -10,6 +16,166 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 _SNIPPET_NAME_PROPERTY_NAME = "snippetname"
 _SNIPPET_PROPERTY_NAME = "snippet"
 _BLOB_PATH = "snippets/{mcptoolargs." + _SNIPPET_NAME_PROPERTY_NAME + "}.json"
+
+
+def mask_secret(secret: str, show: int = 4) -> str:
+    """Redacts a secret value for safe logging."""
+    if not secret:
+        return ""
+    return f"{secret[:show]}...{secret[-show:]}" if len(secret) > show * 2 else "***"
+
+
+def validate_jwt_token(access_token: str, audience: Optional[str] = None, issuer: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Validates a JWT token with signature verification.
+    
+    Args:
+        access_token (str): The JWT token to validate
+        audience (str, optional): Expected audience claim
+        issuer (str, optional): Expected issuer claim
+        
+    Returns:
+        Dict[str, Any]: Dictionary containing validation result and token claims
+    """
+    try:
+        logging.info("Starting JWT token validation")
+        logging.info(access_token)
+        # Decode the token header to get algorithm and key ID
+        unverified_header = jwt.get_unverified_header(access_token)
+        algorithm = unverified_header.get('alg', 'RS256')
+        kid = unverified_header.get('kid')
+        
+        logging.info(f"Token algorithm: {algorithm}, Key ID: {kid}")
+        
+        # First, decode without verification to get claims for issuer discovery
+        unverified_claims = jwt.decode(access_token, options={"verify_signature": False})
+        token_issuer = unverified_claims.get('iss')
+        
+        logging.info(f"Token issuer: {token_issuer}")
+        
+        # Try to get the signing key
+        signing_key = None
+        
+        if token_issuer:
+            try:
+                # Try to discover JWKS endpoint from OpenID configuration
+                if token_issuer.endswith('/'):
+                    token_issuer = token_issuer.rstrip('/')
+                
+                # Common patterns for JWKS URLs
+                jwks_urls = [
+                    f"{token_issuer}/.well-known/jwks.json",
+                    f"{token_issuer}/common/discovery/keys",
+                    f"{token_issuer}/discovery/keys"
+                ]
+                
+                # Try Microsoft Entra ID patterns
+                if 'login.microsoftonline.com' in token_issuer or 'sts.windows.net' in token_issuer:
+                    tenant_id = token_issuer.split('/')[-1]
+                    jwks_urls.insert(0, f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys")
+                    jwks_urls.insert(1, f"https://login.microsoftonline.com/common/discovery/keys")
+                
+                # Try to fetch the JWKS
+                for jwks_url in jwks_urls:
+                    try:
+                        logging.info(f"Trying JWKS URL: {jwks_url}")
+                        jwks_client = PyJWKClient(jwks_url)
+                        signing_key = jwks_client.get_signing_key_from_jwt(access_token)
+                        logging.info(f"Successfully obtained signing key from: {jwks_url}")
+                        break
+                    except Exception as e:
+                        logging.warning(f"Failed to get signing key from {jwks_url}: {str(e)}")
+                        continue
+                        
+            except Exception as e:
+                logging.warning(f"Failed to discover JWKS endpoint: {str(e)}")
+        
+        if not signing_key:
+            return {
+                "valid": False,
+                "error": "Unable to obtain signing key for token validation",
+                "claims": unverified_claims
+            }
+        
+        # Validate the token with signature verification
+        options = {
+            "verify_signature": True,
+            "verify_exp": True,
+            "verify_iat": True,
+            "verify_nbf": True,
+            "verify_aud": False,  # Default to False, can be overridden
+            "verify_iss": False,   # Default to True, can be overridden
+        }
+        
+        # Set verification options based on provided parameters
+        if audience:
+            options["verify_aud"] = False
+        if issuer:
+            options["verify_iss"] = True
+            
+        decode_kwargs = {
+            "algorithms": [algorithm],
+            "options": options
+        }
+        
+        if audience:
+            decode_kwargs["audience"] = audience
+        if issuer:
+            decode_kwargs["issuer"] = issuer
+            
+        # Decode and verify the token
+        verified_claims = jwt.decode(
+            access_token,
+            signing_key.key,
+            **decode_kwargs
+        )
+        
+        logging.info("JWT token validation successful")
+        return {
+            "valid": True,
+            "claims": verified_claims,
+            "header": unverified_header
+        }
+        
+    except jwt.ExpiredSignatureError:
+        return {
+            "valid": False,
+            "error": "Token has expired",
+            "claims": unverified_claims if 'unverified_claims' in locals() else None
+        }
+    except jwt.InvalidAudienceError:
+        expected_aud = audience if audience else "not specified"
+        token_aud = unverified_claims.get('aud') if 'unverified_claims' in locals() else "unknown"
+        return {
+            "valid": False,
+            "error": f"Invalid audience. Expected: '{expected_aud}', Found in token: '{token_aud}'",
+            "claims": unverified_claims if 'unverified_claims' in locals() else None
+        }
+    except jwt.InvalidIssuerError:
+        return {
+            "valid": False,
+            "error": "Invalid issuer",
+            "claims": unverified_claims if 'unverified_claims' in locals() else None
+        }
+    except jwt.InvalidSignatureError:
+        return {
+            "valid": False,
+            "error": "Invalid token signature",
+            "claims": unverified_claims if 'unverified_claims' in locals() else None
+        }
+    except jwt.InvalidTokenError as e:
+        return {
+            "valid": False,
+            "error": f"Invalid token: {str(e)}",
+            "claims": unverified_claims if 'unverified_claims' in locals() else None
+        }
+    except Exception as e:
+        logging.error(f"Unexpected error during JWT validation: {str(e)}")
+        return {
+            "valid": False,
+            "error": f"Validation error: {str(e)}",
+            "claims": unverified_claims if 'unverified_claims' in locals() else None
+        }
 
 
 @dataclass
@@ -36,20 +202,88 @@ tool_properties_get_snippets_json = json.dumps([prop.__dict__ for prop in tool_p
     arg_name="context",
     type="mcpToolTrigger",
     toolName="hello_mcp",
-    description="Hello world.",
+    description="Hello world with JWT token validation.",
     toolProperties="[]",
 )
 def hello_mcp(context) -> str:
     """
-    A simple function that returns a greeting message.
+    A function that validates a JWT token and returns validation results.
 
     Args:
-        context: The trigger context (not used in this function).
+        context: The trigger context containing the bearer token.
 
     Returns:
-        str: A greeting message.
+        str: Validation result message with token details.
     """
-    return "Hello I am MCPTool!"
+    # Parse context
+    try:
+        context_obj = json.loads(context) if isinstance(context, str) else context
+    except Exception as e:
+        logging.error("Invalid context JSON: %s", e)
+        return "Invalid request: context is not valid JSON."
+
+    # Validate arguments
+    arguments = context_obj.get('arguments')
+    if not isinstance(arguments, dict):
+        return "Invalid request: 'arguments' object is missing."
+
+    # Get bearer token
+    bearer_token = arguments.get('bearerToken')
+    if not bearer_token:
+        return "Invalid request: 'bearerToken' is missing."
+
+    # Normalize access token from bearerToken (supports raw token or JSON with access_token)
+    access_token = None
+    if isinstance(bearer_token, str):
+        try:
+            token_data = json.loads(bearer_token)
+            access_token = token_data.get('access_token')
+        except Exception:
+            # Treat the string itself as the access token (e.g., JWT or opaque token)
+            access_token = bearer_token
+    elif isinstance(bearer_token, dict):
+        access_token = bearer_token.get('access_token')
+
+    if not access_token:
+        return "Invalid request: 'access_token' not found in 'bearerToken'."
+
+    logging.info("Received access token (%d chars): %s", len(access_token), mask_secret(access_token))
+    
+    # Validate the JWT token
+    validation_result = validate_jwt_token(access_token)
+    
+    # Format the response
+    if validation_result["valid"]:
+        claims = validation_result.get("claims", {})
+        response = {
+            "status": "valid",
+            "message": "JWT token is valid and signature verified",
+            "token_info": {
+                "issuer": claims.get("iss"),
+                "audience": claims.get("aud"),
+                "subject": claims.get("sub"),
+                "expiry": claims.get("exp"),
+                "issued_at": claims.get("iat"),
+                "not_before": claims.get("nbf"),
+                "token_id": claims.get("jti"),
+                "scope": claims.get("scope"),
+                "client_id": claims.get("client_id"),
+                "app_id": claims.get("appid")
+            },
+            "header": validation_result.get("header")
+        }
+        
+        # Remove None values from token_info
+        response["token_info"] = {k: v for k, v in response["token_info"].items() if v is not None}
+        
+        return json.dumps(response, indent=2)
+    else:
+        error_response = {
+            "status": "invalid",
+            "error": validation_result.get("error", "Unknown validation error"),
+            "claims": validation_result.get("claims")
+        }
+        return json.dumps(error_response, indent=2)
 
 
 @app.generic_trigger(
@@ -71,8 +305,16 @@ def get_snippet(file: func.InputStream, context) -> str:
     Returns:
         str: The content of the snippet or an error message.
     """
-    snippet_content = file.read().decode("utf-8")
-    logging.info("Retrieved snippet: %s", snippet_content)
+    if not file:
+        return "Snippet not found."
+
+    try:
+        snippet_content = file.read().decode("utf-8")
+    except Exception as e:
+        logging.error("Failed to read snippet: %s", e)
+        return "Failed to read snippet."
+
+    logging.info("Retrieved snippet of %d bytes", len(snippet_content))
     return snippet_content
 
 
@@ -85,8 +327,13 @@ def get_snippet(file: func.InputStream, context) -> str:
 )
 @app.generic_output_binding(arg_name="file", type="blob", connection="AzureWebJobsStorage", path=_BLOB_PATH)
 def save_snippet(file: func.Out[str], context) -> str:
-    content = json.loads(context)
-    if "arguments" not in content:
+    try:
+        content = json.loads(context) if isinstance(context, str) else context
+    except Exception as e:
+        logging.error("Invalid context JSON: %s", e)
+        return "Invalid request: context is not valid JSON."
+
+    if "arguments" not in content or not isinstance(content["arguments"], dict):
         return "No arguments provided"
 
     snippet_name_from_args = content["arguments"].get(_SNIPPET_NAME_PROPERTY_NAME)
@@ -98,6 +345,11 @@ def save_snippet(file: func.Out[str], context) -> str:
     if not snippet_content_from_args:
         return "No snippet content provided"
 
-    file.set(snippet_content_from_args)
-    logging.info("Saved snippet: %s", snippet_content_from_args)
+    try:
+        file.set(snippet_content_from_args)
+    except Exception as e:
+        logging.error("Failed to save snippet: %s", e)
+        return "Failed to save snippet."
+
+    logging.info("Saved snippet of %d bytes", len(snippet_content_from_args))
     return f"Snippet '{snippet_content_from_args}' saved successfully"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,6 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions
+PyJWT[crypto]>=2.8.0
+cryptography>=41.0.0
+requests>=2.31.0


### PR DESCRIPTION
## Purpose
This PR does 2 things:

1. It changes the requested scope of the requested access token. It was requesting access token from Graph (`https://graph.microsoft.com/user. Read`). This  introduced an error where the signature of the access token is invalid. As the access token was sent to MCP Server is also violates the rule that an MCP server should only accept it's own access token (meaning that the audience is from it own corresponding app registration, see https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#token-handling).  
The scope has been change to api://clientid/access_as_user that is added to the app registration in the entra-app.bicep. Also the policies have been changed to use this new scope.
2. Adds a new tool `validate_token`. This get the token from the request (it is now added to requests to mcp server) and validated. Returns validation result
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[] Yes
[X] No

The exising tools remain to work as expected, but the app registration will change as the Application URI ID and scope need to be set. Also the token output will be send to mcp server on every request to/message.
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]

azd up 
```

* Test the code

```
Run the validate_token tool to get result of the access token validation
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->